### PR TITLE
Add incremental improvements and tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,27 @@
+name: Python package
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11']
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Run tests
+      run: |
+        pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Python artifacts
+__pycache__/
+*.py[cod]
+
+# Environment files
+.env
+
+# Output directories
+output/
+

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 # Output directories
 output/
 
+buck_visualizer/data-viz/

--- a/README.md
+++ b/README.md
@@ -183,6 +183,9 @@ market_forecaster/
 
 ### Environment Variables
 
+Create a `.env` file in the project root to store these variables. The
+`.gitignore` file already excludes `.env` so your secrets remain private.
+
 ```bash
 # Required
 OPENAI_API_KEY=your-openai-api-key

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Buck_V1
 An agent that helps you predict the next day's stock data.
 
-# 🤖 BUCK (Version 1.4.0) - AI-Powered Stock Analysis & Prediction
+# 🤖 BUCK (Version 1.4.1) - AI-Powered Stock Analysis & Prediction
 
 A production-ready stock analysis and prediction system that combines technical analysis, sentiment analysis, and AI-powered forecasting using OpenAI models.
 
@@ -31,6 +31,12 @@ pip install -r requirements.txt
 # Set up environment variables
 export OPENAI_API_KEY="your-openai-api-key"
 export INDIAN_API_KEY="your-indian-api-key"  # Optional for news data
+
+# Or configure keys once using Python (creates a .env file)
+python - <<'EOF'
+from agent_scripts import set_api_keys
+set_api_keys("your-openai-api-key", "your-indian-api-key")
+EOF
 ```
 
 ### Basic Usage
@@ -185,6 +191,13 @@ market_forecaster/
 
 Create a `.env` file in the project root to store these variables. The
 `.gitignore` file already excludes `.env` so your secrets remain private.
+
+You can generate this file automatically using `set_api_keys`:
+
+```python
+from agent_scripts import set_api_keys
+set_api_keys("your-openai-key", "your-indian-key")
+```
 
 ```bash
 # Required

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Buck_V1
 An agent that helps you predict the next day's stock data.
 
-# 🤖 BUCK (Version 1.0.0) - AI-Powered Stock Analysis & Prediction
+# 🤖 BUCK (Version 1.4.0) - AI-Powered Stock Analysis & Prediction
 
 A production-ready stock analysis and prediction system that combines technical analysis, sentiment analysis, and AI-powered forecasting using OpenAI models.
 
@@ -194,6 +194,7 @@ TEMPERATURE=0.1
 MAX_COMPLETION_TOKENS=500
 NEWS_ITEMS=10
 LOG_LEVEL=INFO
+OUTPUT_DIR=output
 ```
 
 ### Custom Configuration

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A production-ready stock analysis and prediction system that combines technical 
 ```bash
 # Clone the repository
 git clone https://github.com/RyoK3N/Buck_V1
-cd agent-scripts
+cd Buck_V1
 
 # Install dependencies
 pip install -r requirements.txt
@@ -43,7 +43,7 @@ EOF
 
 ```python
 import asyncio
-from agent-scripts import create_agent
+from agent_scripts import create_agent
 
 async def analyze_stock_example():
     # Create the agent
@@ -77,13 +77,13 @@ asyncio.run(analyze_stock_example())
 
 ```bash
 # Analyze a single stock
-python -m agent-scripts.cli analyze BHEL.NS --start 2025-06-18 --end 2024-06-20
+python -m agent_scripts.cli analyze BHEL.NS --start 2025-06-18 --end 2024-06-20
 
 # Run demo
-python -m agent-scripts.cli demo --symbol BHEL.NS
+python -m agent_scripts.cli demo --symbol BHEL.NS
 
 # Use custom parameters
-python -m agent-scripts.cli analyze BHEL.NS \
+python -m agent_scripts.cli analyze BHEL.NS \
   --start 2024-01-01 \
   --end 2024-01-10 \
   --interval 30m \
@@ -98,7 +98,7 @@ python -m agent-scripts.cli analyze BHEL.NS \
 The main orchestrator class that coordinates data collection, analysis, and prediction.
 
 ```python
-from agent-scripts import BuckFactory
+from agent_scripts import BuckFactory
 
 # Create with default settings
 agent = BuckFactory.create_default_agent()
@@ -216,8 +216,8 @@ OUTPUT_DIR=output
 ### Custom Configuration
 
 ```python
-from agent-scripts.interfaces import BuckConfig
-from agent-scripts import BuckFactory
+from agent_scripts.interfaces import BuckConfig
+from agent_scripts import BuckFactory
 
 config = BuckConfig(
     openai_api_key="your-key",

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ export CHAT_MODEL="gpt-4o"
 ```
 ## 📊 Visualization Scripts
 
-The `buck_visualizer` folder contains helper scripts for plotting stock and news data. Each script downloads fresh data using `data_provider_viz.py`. Example:
+The `buck_visualizer` folder contains helper scripts for **interactive** Plotly charts. Each script downloads fresh data via `data_provider_viz.py` and then displays an interactive figure with helpful explanations. Example:
 
 ```bash
 python buck_visualizer/price_ma_plot.py BHEL.NS 2024-01-01 2024-01-31
@@ -309,6 +309,12 @@ Available scripts:
 - volatility_plot.py
 - returns_histogram.py
 - news_overlay_plot.py
+
+These scripts require the optional `plotly` dependency. Install it via:
+
+```bash
+pip install -r requirements.txt
+```
 
 
 ## 🤝 Contributing

--- a/README.md
+++ b/README.md
@@ -292,6 +292,24 @@ export INDIAN_API_KEY="prod-indian-key"
 export LOG_LEVEL="INFO"
 export CHAT_MODEL="gpt-4o"
 ```
+## 📊 Visualization Scripts
+
+The `buck_visualizer` folder contains helper scripts for plotting stock and news data. Each script downloads fresh data using `data_provider_viz.py`. Example:
+
+```bash
+python buck_visualizer/price_ma_plot.py BHEL.NS 2024-01-01 2024-01-31
+```
+
+Available scripts:
+- price_ma_plot.py
+- candlestick_volume_plot.py
+- macd_plot.py
+- bollinger_plot.py
+- rsi_plot.py
+- volatility_plot.py
+- returns_histogram.py
+- news_overlay_plot.py
+
 
 ## 🤝 Contributing
 

--- a/agent_scripts/__init__.py
+++ b/agent_scripts/__init__.py
@@ -14,10 +14,10 @@ Licensed under the Apache License 2.0 – see LICENSE file for details.
 """
 
 from .buck import Buck, BuckFactory
-from .config import SETTINGS, LOGGER
+from .config import SETTINGS, LOGGER, set_api_keys, ensure_api_keys
 from .interfaces import Forecast, AnalysisResult, StockData, NewsData
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 __author__ = "Buck Dev Team"
 __description__ = "AI-Powered Stock Analysis and Prediction Agent that helps you make bucks"
 
@@ -31,6 +31,8 @@ __all__ = [
     "AnalysisResult",
     "StockData",
     "NewsData",
+    "set_api_keys",
+    "ensure_api_keys",
 ]
 
 # Convenience functions

--- a/agent_scripts/__init__.py
+++ b/agent_scripts/__init__.py
@@ -17,7 +17,7 @@ from .buck import Buck, BuckFactory
 from .config import SETTINGS, LOGGER
 from .interfaces import Forecast, AnalysisResult, StockData, NewsData
 
-__version__ = "1.0.0"
+__version__ = "1.4.0"
 __author__ = "Buck Dev Team"
 __description__ = "AI-Powered Stock Analysis and Prediction Agent that helps you make bucks"
 

--- a/agent_scripts/buck.py
+++ b/agent_scripts/buck.py
@@ -277,8 +277,8 @@ class Buck:
             symbol = results['symbol']
             timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
             
-            # Create output directory
-            output_dir = Path('output')
+            # Create output directory from settings
+            output_dir = Path(SETTINGS.output_dir)
             output_dir.mkdir(exist_ok=True)
             
             # Save complete results
@@ -319,7 +319,7 @@ class Buck:
     def _create_default_data_provider(self) -> IDataProvider:
         """Create default data provider."""
         # Use Indian API key if available, otherwise empty string
-        indian_api_key = getattr(SETTINGS, 'indian_api_key', 'sk-live-7rblZdIQfghdIsfucGOdos5iPSXsevk0zcKbtTev')
+        indian_api_key = getattr(SETTINGS, 'indian_api_key', '')
         
         return DataProviderFactory.create_composite_provider(
             yahoo_timeout=30,

--- a/agent_scripts/cli.py
+++ b/agent_scripts/cli.py
@@ -68,6 +68,7 @@ Examples:
     parser.add_argument('--api-key', help='OpenAI API key (or set OPENAI_API_KEY env var)')
     parser.add_argument('--indian-api-key', help='Indian API key for news data')
     parser.add_argument('--verbose', '-v', action='store_true', help='Verbose logging')
+    parser.add_argument('--version', action='store_true', help='Show version and exit')
     
     return parser
 
@@ -188,7 +189,8 @@ async def run_batch_analysis(args) -> None:
         if args.output:
             output_dir = Path(args.output)
         else:
-            output_dir = Path('output')
+            from .config import SETTINGS
+            output_dir = Path(SETTINGS.output_dir)
             
         output_dir.mkdir(exist_ok=True)
         timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
@@ -237,6 +239,11 @@ async def main() -> None:
     """Main CLI entry point."""
     parser = setup_cli()
     args = parser.parse_args()
+
+    if getattr(args, 'version', False):
+        from . import __version__
+        print(__version__)
+        return
     
     if not args.command:
         parser.print_help()

--- a/agent_scripts/cli.py
+++ b/agent_scripts/cli.py
@@ -256,13 +256,11 @@ async def main() -> None:
     
     # Validate API key
     if not args.api_key:
-        try:
-            from .config import SETTINGS
-            if not SETTINGS.openai_api_key:
-                print("❌ Error: OpenAI API key required. Set OPENAI_API_KEY env var or use --api-key")
-                return
-        except Exception:
-            print("❌ Error: OpenAI API key required. Set OPENAI_API_KEY env var or use --api-key")
+        from .config import ensure_api_keys
+        if not ensure_api_keys():
+            print(
+                "❌ Error: OpenAI API key required. Use `set_api_keys` or set OPENAI_API_KEY env var."
+            )
             return
     
     # Route to appropriate command

--- a/agent_scripts/config.py
+++ b/agent_scripts/config.py
@@ -22,7 +22,7 @@ class Settings(BaseSettings):
     embed_model: str = "text-embedding-ada-002"
 
     # --- Indian API for News -----------------------------------------------
-    indian_api_key: str = Field("sk-live-7rblZdIQfghdIsfucGOdos5iPSXsevk0zcKbtTev", env="INDIAN_API_KEY")
+    indian_api_key: str = Field("", env="INDIAN_API_KEY")
 
     # --- Generation controls -----------------------------------------------
     temperature: float = 0.0                   # deterministic JSON
@@ -30,6 +30,9 @@ class Settings(BaseSettings):
 
     # --- Domain tweaks ------------------------------------------------------
     news_items: int = 8
+
+    # --- Output -------------------------------------------------------------
+    output_dir: str = Field("output", env="OUTPUT_DIR")
 
     # --- Logging ------------------------------------------------------------
     log_level: str = "INFO"

--- a/buck_visualizer/bollinger_plot.py
+++ b/buck_visualizer/bollinger_plot.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import matplotlib.pyplot as plt
+import plotly.graph_objects as go
 import pandas as pd
 
 from data_provider_viz import DataVisualizationDownloader, fix_imports
@@ -27,17 +27,34 @@ def preprocess(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
+DESCRIPTION = """
+Bollinger Bands consist of a moving average with upper and lower bands set two
+standard deviations away. Price touching the bands can indicate overbought or
+oversold conditions. Hover to explore.
+"""
+
+
 def plot(df: pd.DataFrame, symbol: str) -> None:
-    plt.figure(figsize=(10,6))
-    plt.plot(df.index, df['Close'], label='Close')
-    plt.plot(df.index, df['MA20'], label='MA20')
-    plt.fill_between(df.index, df['Upper'], df['Lower'], color='gray', alpha=0.3, label='Bollinger Band')
-    plt.title(f'{symbol} Bollinger Bands')
-    plt.xlabel('Date')
-    plt.ylabel('Price')
-    plt.legend()
-    plt.tight_layout()
-    plt.show()
+    fig = go.Figure()
+    fig.add_trace(go.Scatter(x=df.index, y=df['Close'], name='Close'))
+    fig.add_trace(go.Scatter(x=df.index, y=df['MA20'], name='MA20'))
+    fig.add_trace(go.Scatter(
+        x=df.index, y=df['Upper'], name='Upper Band', line=dict(color='lightgrey'),
+    ))
+    fig.add_trace(go.Scatter(
+        x=df.index, y=df['Lower'], name='Lower Band', fill='tonexty',
+        line=dict(color='lightgrey')
+    ))
+
+    fig.update_layout(
+        title=f'{symbol} Bollinger Bands',
+        xaxis_title='Date',
+        yaxis_title='Price',
+        hovermode='x unified'
+    )
+
+    fig.show()
+    print(DESCRIPTION)
 
 
 async def main() -> None:

--- a/buck_visualizer/bollinger_plot.py
+++ b/buck_visualizer/bollinger_plot.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from data_provider_viz import DataVisualizationDownloader, fix_imports
+
+fix_imports()
+
+async def fetch(symbol: str, start: str, end: str, interval: str) -> pd.DataFrame:
+    downloader = DataVisualizationDownloader()
+    csv = await downloader.download_stock_data(symbol, start, end, interval)
+    if not csv:
+        raise RuntimeError('Failed to download stock data')
+    return pd.read_csv(csv, parse_dates=True, index_col=0)
+
+
+def preprocess(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.sort_index()
+    ma = df['Close'].rolling(20).mean()
+    std = df['Close'].rolling(20).std()
+    df['MA20'] = ma
+    df['Upper'] = ma + 2 * std
+    df['Lower'] = ma - 2 * std
+    return df
+
+
+def plot(df: pd.DataFrame, symbol: str) -> None:
+    plt.figure(figsize=(10,6))
+    plt.plot(df.index, df['Close'], label='Close')
+    plt.plot(df.index, df['MA20'], label='MA20')
+    plt.fill_between(df.index, df['Upper'], df['Lower'], color='gray', alpha=0.3, label='Bollinger Band')
+    plt.title(f'{symbol} Bollinger Bands')
+    plt.xlabel('Date')
+    plt.ylabel('Price')
+    plt.legend()
+    plt.tight_layout()
+    plt.show()
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description='Bollinger Bands plot')
+    parser.add_argument('symbol')
+    parser.add_argument('start_date')
+    parser.add_argument('end_date')
+    parser.add_argument('--interval', default='1d')
+    args = parser.parse_args()
+
+    df = await fetch(args.symbol, args.start_date, args.end_date, args.interval)
+    df = preprocess(df)
+    plot(df, args.symbol)
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/buck_visualizer/candlestick_volume_plot.py
+++ b/buck_visualizer/candlestick_volume_plot.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from data_provider_viz import DataVisualizationDownloader, fix_imports
+
+fix_imports()
+
+async def fetch(symbol: str, start: str, end: str, interval: str) -> pd.DataFrame:
+    downloader = DataVisualizationDownloader()
+    csv = await downloader.download_stock_data(symbol, start, end, interval)
+    if not csv:
+        raise RuntimeError('Failed to download stock data')
+    return pd.read_csv(csv, parse_dates=True, index_col=0)
+
+
+def preprocess(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.sort_index()
+    return df
+
+
+def plot(df: pd.DataFrame, symbol: str) -> None:
+    fig, ax1 = plt.subplots(figsize=(10,6))
+    width = 0.6
+    up = df['Close'] >= df['Open']
+    down = ~up
+    ax1.bar(df.index[up], df['Close'][up]-df['Open'][up], width, bottom=df['Open'][up], color='g')
+    ax1.bar(df.index[down], df['Open'][down]-df['Close'][down], width, bottom=df['Close'][down], color='r')
+    ax1.vlines(df.index, df['Low'], df['High'], color='k', linewidth=0.5)
+    ax1.set_title(f'{symbol} Candlestick')
+    ax1.set_ylabel('Price')
+
+    ax2 = ax1.twinx()
+    ax2.bar(df.index, df['Volume'], width, alpha=0.3, color='b')
+    ax2.set_ylabel('Volume')
+
+    fig.autofmt_xdate()
+    plt.tight_layout()
+    plt.show()
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description='Candlestick with volume plot')
+    parser.add_argument('symbol')
+    parser.add_argument('start_date')
+    parser.add_argument('end_date')
+    parser.add_argument('--interval', default='1d')
+    args = parser.parse_args()
+
+    df = await fetch(args.symbol, args.start_date, args.end_date, args.interval)
+    df = preprocess(df)
+    plot(df, args.symbol)
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/buck_visualizer/macd_plot.py
+++ b/buck_visualizer/macd_plot.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from data_provider_viz import DataVisualizationDownloader, fix_imports
+
+fix_imports()
+
+async def fetch(symbol: str, start: str, end: str, interval: str) -> pd.DataFrame:
+    downloader = DataVisualizationDownloader()
+    csv = await downloader.download_stock_data(symbol, start, end, interval)
+    if not csv:
+        raise RuntimeError('Failed to download stock data')
+    return pd.read_csv(csv, parse_dates=True, index_col=0)
+
+
+def preprocess(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.sort_index()
+    exp1 = df['Close'].ewm(span=12, adjust=False).mean()
+    exp2 = df['Close'].ewm(span=26, adjust=False).mean()
+    df['MACD'] = exp1 - exp2
+    df['Signal'] = df['MACD'].ewm(span=9, adjust=False).mean()
+    return df
+
+
+def plot(df: pd.DataFrame, symbol: str) -> None:
+    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10,7), sharex=True)
+    ax1.plot(df.index, df['Close'], label='Close')
+    ax1.set_title(f'{symbol} Price')
+
+    ax2.plot(df.index, df['MACD'], label='MACD')
+    ax2.plot(df.index, df['Signal'], label='Signal')
+    ax2.axhline(0, color='black', linewidth=0.5)
+    ax2.set_title('MACD')
+    ax2.legend()
+
+    plt.tight_layout()
+    plt.show()
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description='MACD plot')
+    parser.add_argument('symbol')
+    parser.add_argument('start_date')
+    parser.add_argument('end_date')
+    parser.add_argument('--interval', default='1d')
+    args = parser.parse_args()
+
+    df = await fetch(args.symbol, args.start_date, args.end_date, args.interval)
+    df = preprocess(df)
+    plot(df, args.symbol)
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/buck_visualizer/macd_plot.py
+++ b/buck_visualizer/macd_plot.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import matplotlib.pyplot as plt
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
 import pandas as pd
 
 from data_provider_viz import DataVisualizationDownloader, fix_imports
@@ -26,19 +27,31 @@ def preprocess(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
+DESCRIPTION = """
+MACD (Moving Average Convergence Divergence) highlights momentum shifts.
+The MACD line crossing above the signal line may indicate bullishness and
+vice versa. Hover to inspect exact values.
+"""
+
+
 def plot(df: pd.DataFrame, symbol: str) -> None:
-    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10,7), sharex=True)
-    ax1.plot(df.index, df['Close'], label='Close')
-    ax1.set_title(f'{symbol} Price')
+    fig = make_subplots(rows=2, cols=1, shared_xaxes=True, vertical_spacing=0.02)
 
-    ax2.plot(df.index, df['MACD'], label='MACD')
-    ax2.plot(df.index, df['Signal'], label='Signal')
-    ax2.axhline(0, color='black', linewidth=0.5)
-    ax2.set_title('MACD')
-    ax2.legend()
+    fig.add_trace(go.Scatter(x=df.index, y=df['Close'], name='Close'), row=1, col=1)
+    fig.add_trace(go.Scatter(x=df.index, y=df['MACD'], name='MACD'), row=2, col=1)
+    fig.add_trace(go.Scatter(x=df.index, y=df['Signal'], name='Signal'), row=2, col=1)
+    fig.add_hline(y=0, line_dash='dash', row=2, col=1)
 
-    plt.tight_layout()
-    plt.show()
+    fig.update_layout(
+        title=f'{symbol} Price and MACD',
+        xaxis_title='Date',
+        yaxis_title='Price',
+        yaxis2_title='MACD',
+        hovermode='x unified'
+    )
+
+    fig.show()
+    print(DESCRIPTION)
 
 
 async def main() -> None:

--- a/buck_visualizer/news_overlay_plot.py
+++ b/buck_visualizer/news_overlay_plot.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+from datetime import datetime
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from data_provider_viz import DataVisualizationDownloader, fix_imports
+
+fix_imports()
+
+async def fetch(symbol: str, start: str, end: str, interval: str, api_key: str) -> tuple[pd.DataFrame, pd.DataFrame]:
+    downloader = DataVisualizationDownloader(indian_api_key=api_key)
+    stock_csv, news_csv = await downloader.download_all_data(symbol, start, end, interval)
+    if not stock_csv:
+        raise RuntimeError('Failed to download stock data')
+    stock_df = pd.read_csv(stock_csv, parse_dates=True, index_col=0)
+    news_df = pd.DataFrame()
+    if news_csv:
+        news_df = pd.read_csv(news_csv, parse_dates=['pub_date'])
+    return stock_df, news_df
+
+
+def preprocess(stock: pd.DataFrame, news: pd.DataFrame) -> tuple[pd.DataFrame, pd.Series]:
+    stock = stock.sort_index()
+    times = pd.Series(dtype='datetime64[ns]')
+    if not news.empty:
+        times = pd.to_datetime(news['pub_date']).dt.floor('min')
+    return stock, times
+
+
+def plot(stock: pd.DataFrame, news_times: pd.Series, symbol: str) -> None:
+    plt.figure(figsize=(10,6))
+    plt.plot(stock.index, stock['Close'], label='Close')
+    for t in news_times:
+        plt.axvline(t, color='r', linestyle='--', alpha=0.4)
+    plt.title(f'{symbol} Price with News Releases')
+    plt.xlabel('Date')
+    plt.ylabel('Price')
+    plt.tight_layout()
+    plt.show()
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description='Overlay news times on price chart')
+    parser.add_argument('symbol')
+    parser.add_argument('start_date')
+    parser.add_argument('end_date')
+    parser.add_argument('--interval', default='1d')
+    parser.add_argument('--api-key', default='')
+    args = parser.parse_args()
+
+    stock_df, news_df = await fetch(args.symbol, args.start_date, args.end_date, args.interval, args.api_key)
+    stock_df, times = preprocess(stock_df, news_df)
+    plot(stock_df, times, args.symbol)
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/buck_visualizer/news_overlay_plot.py
+++ b/buck_visualizer/news_overlay_plot.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 from datetime import datetime
-import matplotlib.pyplot as plt
+import plotly.graph_objects as go
 import pandas as pd
 
 from data_provider_viz import DataVisualizationDownloader, fix_imports
@@ -30,16 +30,28 @@ def preprocess(stock: pd.DataFrame, news: pd.DataFrame) -> tuple[pd.DataFrame, p
     return stock, times
 
 
+DESCRIPTION = """
+Vertical lines mark when news articles were published relative to price.
+Clusters of news around major moves may highlight cause and effect. Hover on
+the price line to view specific values.
+"""
+
+
 def plot(stock: pd.DataFrame, news_times: pd.Series, symbol: str) -> None:
-    plt.figure(figsize=(10,6))
-    plt.plot(stock.index, stock['Close'], label='Close')
+    fig = go.Figure()
+    fig.add_trace(go.Scatter(x=stock.index, y=stock['Close'], name='Close'))
     for t in news_times:
-        plt.axvline(t, color='r', linestyle='--', alpha=0.4)
-    plt.title(f'{symbol} Price with News Releases')
-    plt.xlabel('Date')
-    plt.ylabel('Price')
-    plt.tight_layout()
-    plt.show()
+        fig.add_vline(x=t, line_dash='dash', line_color='red', opacity=0.4)
+
+    fig.update_layout(
+        title=f'{symbol} Price with News Releases',
+        xaxis_title='Date',
+        yaxis_title='Price',
+        hovermode='x unified'
+    )
+
+    fig.show()
+    print(DESCRIPTION)
 
 
 async def main() -> None:

--- a/buck_visualizer/price_ma_plot.py
+++ b/buck_visualizer/price_ma_plot.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from data_provider_viz import DataVisualizationDownloader, fix_imports
+
+# Ensure we can import agent_scripts
+fix_imports()
+
+
+async def fetch_stock(symbol: str, start: str, end: str, interval: str) -> pd.DataFrame:
+    downloader = DataVisualizationDownloader()
+    csv_path = await downloader.download_stock_data(symbol, start, end, interval)
+    if not csv_path:
+        raise RuntimeError("Failed to download stock data")
+    return pd.read_csv(csv_path, parse_dates=True, index_col=0)
+
+
+def preprocess(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.sort_index()
+    df['MA20'] = df['Close'].rolling(20).mean()
+    df['MA50'] = df['Close'].rolling(50).mean()
+    return df
+
+
+def plot(df: pd.DataFrame, symbol: str) -> None:
+    plt.figure(figsize=(10, 6))
+    plt.plot(df.index, df['Close'], label='Close')
+    plt.plot(df.index, df['MA20'], label='MA20')
+    plt.plot(df.index, df['MA50'], label='MA50')
+    plt.title(f'{symbol} Price with Moving Averages')
+    plt.xlabel('Date')
+    plt.ylabel('Price')
+    plt.legend()
+    plt.tight_layout()
+    plt.show()
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description='Plot price with moving averages')
+    parser.add_argument('symbol')
+    parser.add_argument('start_date')
+    parser.add_argument('end_date')
+    parser.add_argument('--interval', default='1d')
+    args = parser.parse_args()
+
+    df = await fetch_stock(args.symbol, args.start_date, args.end_date, args.interval)
+    df = preprocess(df)
+    plot(df, args.symbol)
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/buck_visualizer/price_ma_plot.py
+++ b/buck_visualizer/price_ma_plot.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import matplotlib.pyplot as plt
+import plotly.graph_objects as go
 import pandas as pd
 
 from data_provider_viz import DataVisualizationDownloader, fix_imports
@@ -26,17 +26,26 @@ def preprocess(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
+DESCRIPTION = """
+Interactive price chart with 20- and 50-period moving averages. The moving
+averages help reveal trend direction. Crossovers may hint at shifts in
+momentum. Hover to inspect exact prices.
+"""
+
+
 def plot(df: pd.DataFrame, symbol: str) -> None:
-    plt.figure(figsize=(10, 6))
-    plt.plot(df.index, df['Close'], label='Close')
-    plt.plot(df.index, df['MA20'], label='MA20')
-    plt.plot(df.index, df['MA50'], label='MA50')
-    plt.title(f'{symbol} Price with Moving Averages')
-    plt.xlabel('Date')
-    plt.ylabel('Price')
-    plt.legend()
-    plt.tight_layout()
-    plt.show()
+    fig = go.Figure()
+    fig.add_trace(go.Scatter(x=df.index, y=df["Close"], mode="lines", name="Close"))
+    fig.add_trace(go.Scatter(x=df.index, y=df["MA20"], mode="lines", name="MA20"))
+    fig.add_trace(go.Scatter(x=df.index, y=df["MA50"], mode="lines", name="MA50"))
+    fig.update_layout(
+        title=f"{symbol} Price with Moving Averages",
+        xaxis_title="Date",
+        yaxis_title="Price",
+        hovermode="x unified",
+    )
+    fig.show()
+    print(DESCRIPTION)
 
 
 async def main() -> None:

--- a/buck_visualizer/returns_histogram.py
+++ b/buck_visualizer/returns_histogram.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from data_provider_viz import DataVisualizationDownloader, fix_imports
+
+fix_imports()
+
+async def fetch(symbol: str, start: str, end: str, interval: str) -> pd.DataFrame:
+    downloader = DataVisualizationDownloader()
+    csv = await downloader.download_stock_data(symbol, start, end, interval)
+    if not csv:
+        raise RuntimeError('Failed to download stock data')
+    return pd.read_csv(csv, parse_dates=True, index_col=0)
+
+
+def preprocess(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.sort_index()
+    df['Returns'] = df['Close'].pct_change()
+    return df
+
+
+def plot(df: pd.DataFrame, symbol: str) -> None:
+    plt.figure(figsize=(8,5))
+    df['Returns'].hist(bins=50)
+    plt.title(f'{symbol} Daily Returns Distribution')
+    plt.xlabel('Return')
+    plt.ylabel('Frequency')
+    plt.tight_layout()
+    plt.show()
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description='Daily returns histogram')
+    parser.add_argument('symbol')
+    parser.add_argument('start_date')
+    parser.add_argument('end_date')
+    parser.add_argument('--interval', default='1d')
+    args = parser.parse_args()
+
+    df = await fetch(args.symbol, args.start_date, args.end_date, args.interval)
+    df = preprocess(df)
+    plot(df, args.symbol)
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/buck_visualizer/returns_histogram.py
+++ b/buck_visualizer/returns_histogram.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import matplotlib.pyplot as plt
+import plotly.express as px
 import pandas as pd
 
 from data_provider_viz import DataVisualizationDownloader, fix_imports
@@ -23,14 +23,17 @@ def preprocess(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
+DESCRIPTION = """
+Histogram of daily percentage returns. The distribution's shape highlights
+volatility and skewness. Use the interactive view to inspect tail events.
+"""
+
+
 def plot(df: pd.DataFrame, symbol: str) -> None:
-    plt.figure(figsize=(8,5))
-    df['Returns'].hist(bins=50)
-    plt.title(f'{symbol} Daily Returns Distribution')
-    plt.xlabel('Return')
-    plt.ylabel('Frequency')
-    plt.tight_layout()
-    plt.show()
+    fig = px.histogram(df, x='Returns', nbins=50, title=f'{symbol} Daily Returns Distribution')
+    fig.update_layout(xaxis_title='Return', yaxis_title='Frequency')
+    fig.show()
+    print(DESCRIPTION)
 
 
 async def main() -> None:

--- a/buck_visualizer/rsi_plot.py
+++ b/buck_visualizer/rsi_plot.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from data_provider_viz import DataVisualizationDownloader, fix_imports
+
+fix_imports()
+
+async def fetch(symbol: str, start: str, end: str, interval: str) -> pd.DataFrame:
+    downloader = DataVisualizationDownloader()
+    csv = await downloader.download_stock_data(symbol, start, end, interval)
+    if not csv:
+        raise RuntimeError('Failed to download stock data')
+    return pd.read_csv(csv, parse_dates=True, index_col=0)
+
+
+def preprocess(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.sort_index()
+    delta = df['Close'].diff()
+    up = delta.clip(lower=0)
+    down = -delta.clip(upper=0)
+    roll_up = up.rolling(14).mean()
+    roll_down = down.rolling(14).mean()
+    rs = roll_up / roll_down
+    df['RSI'] = 100 - (100 / (1 + rs))
+    return df
+
+
+def plot(df: pd.DataFrame, symbol: str) -> None:
+    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10,7), sharex=True)
+    ax1.plot(df.index, df['Close'], label='Close')
+    ax1.set_title(f'{symbol} Price')
+
+    ax2.plot(df.index, df['RSI'], label='RSI')
+    ax2.axhline(70, color='r', linestyle='--')
+    ax2.axhline(30, color='g', linestyle='--')
+    ax2.set_title('Relative Strength Index')
+    ax2.legend()
+
+    plt.tight_layout()
+    plt.show()
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description='RSI plot')
+    parser.add_argument('symbol')
+    parser.add_argument('start_date')
+    parser.add_argument('end_date')
+    parser.add_argument('--interval', default='1d')
+    args = parser.parse_args()
+
+    df = await fetch(args.symbol, args.start_date, args.end_date, args.interval)
+    df = preprocess(df)
+    plot(df, args.symbol)
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/buck_visualizer/rsi_plot.py
+++ b/buck_visualizer/rsi_plot.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import matplotlib.pyplot as plt
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
 import pandas as pd
 
 from data_provider_viz import DataVisualizationDownloader, fix_imports
@@ -29,19 +30,30 @@ def preprocess(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
+DESCRIPTION = """
+Relative Strength Index identifies overbought (above 70) and oversold (below 30)
+zones. Values crossing those lines can signal potential reversals. Hover for
+exact readings.
+"""
+
+
 def plot(df: pd.DataFrame, symbol: str) -> None:
-    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10,7), sharex=True)
-    ax1.plot(df.index, df['Close'], label='Close')
-    ax1.set_title(f'{symbol} Price')
+    fig = make_subplots(rows=2, cols=1, shared_xaxes=True, vertical_spacing=0.02)
+    fig.add_trace(go.Scatter(x=df.index, y=df['Close'], name='Close'), row=1, col=1)
+    fig.add_trace(go.Scatter(x=df.index, y=df['RSI'], name='RSI'), row=2, col=1)
+    fig.add_hline(y=70, line_dash='dash', line_color='red', row=2, col=1)
+    fig.add_hline(y=30, line_dash='dash', line_color='green', row=2, col=1)
 
-    ax2.plot(df.index, df['RSI'], label='RSI')
-    ax2.axhline(70, color='r', linestyle='--')
-    ax2.axhline(30, color='g', linestyle='--')
-    ax2.set_title('Relative Strength Index')
-    ax2.legend()
+    fig.update_layout(
+        title=f'{symbol} Price and RSI',
+        xaxis_title='Date',
+        yaxis_title='Price',
+        yaxis2_title='RSI',
+        hovermode='x unified'
+    )
 
-    plt.tight_layout()
-    plt.show()
+    fig.show()
+    print(DESCRIPTION)
 
 
 async def main() -> None:

--- a/buck_visualizer/volatility_plot.py
+++ b/buck_visualizer/volatility_plot.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from data_provider_viz import DataVisualizationDownloader, fix_imports
+
+fix_imports()
+
+async def fetch(symbol: str, start: str, end: str, interval: str) -> pd.DataFrame:
+    downloader = DataVisualizationDownloader()
+    csv = await downloader.download_stock_data(symbol, start, end, interval)
+    if not csv:
+        raise RuntimeError('Failed to download stock data')
+    return pd.read_csv(csv, parse_dates=True, index_col=0)
+
+
+def preprocess(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.sort_index()
+    returns = df['Close'].pct_change()
+    df['Volatility'] = returns.rolling(30).std() * (252 ** 0.5)
+    return df
+
+
+def plot(df: pd.DataFrame, symbol: str) -> None:
+    fig, ax = plt.subplots(figsize=(10,6))
+    ax.plot(df.index, df['Volatility'], label='30D Volatility')
+    ax.set_title(f'{symbol} Rolling Volatility')
+    ax.set_ylabel('Volatility (annualized)')
+    ax.set_xlabel('Date')
+    plt.tight_layout()
+    plt.show()
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description='Historical volatility plot')
+    parser.add_argument('symbol')
+    parser.add_argument('start_date')
+    parser.add_argument('end_date')
+    parser.add_argument('--interval', default='1d')
+    args = parser.parse_args()
+
+    df = await fetch(args.symbol, args.start_date, args.end_date, args.interval)
+    df = preprocess(df)
+    plot(df, args.symbol)
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/buck_visualizer/volatility_plot.py
+++ b/buck_visualizer/volatility_plot.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import matplotlib.pyplot as plt
+import plotly.graph_objects as go
 import pandas as pd
 
 from data_provider_viz import DataVisualizationDownloader, fix_imports
@@ -24,14 +24,24 @@ def preprocess(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
+DESCRIPTION = """
+Volatility measures the magnitude of price swings. This plot shows the
+annualized standard deviation of daily returns over the last 30 days.
+Rising volatility often signals uncertainty. Hover for precise values.
+"""
+
+
 def plot(df: pd.DataFrame, symbol: str) -> None:
-    fig, ax = plt.subplots(figsize=(10,6))
-    ax.plot(df.index, df['Volatility'], label='30D Volatility')
-    ax.set_title(f'{symbol} Rolling Volatility')
-    ax.set_ylabel('Volatility (annualized)')
-    ax.set_xlabel('Date')
-    plt.tight_layout()
-    plt.show()
+    fig = go.Figure()
+    fig.add_trace(go.Scatter(x=df.index, y=df['Volatility'], name='30D Volatility'))
+    fig.update_layout(
+        title=f'{symbol} Rolling Volatility',
+        xaxis_title='Date',
+        yaxis_title='Volatility (annualized)',
+        hovermode='x unified'
+    )
+    fig.show()
+    print(DESCRIPTION)
 
 
 async def main() -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+pandas
+numpy
+requests
+aiohttp
+yfinance
+beautifulsoup4
+openai
+python-dotenv
+nest_asyncio
+pydantic
+pydantic-settings
+scipy
+pytest
+pytest-asyncio

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ scipy
 pytest
 pytest-asyncio
 matplotlib
+plotly

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pydantic-settings
 scipy
 pytest
 pytest-asyncio
+matplotlib

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,20 @@
+import os
+from agent_scripts.config import set_api_keys, get_settings, ensure_api_keys
+
+
+def test_set_api_keys(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    monkeypatch.chdir(tmp_path)
+    set_api_keys("test-openai", "test-indian", env_file=str(env_file))
+    settings = get_settings()
+    assert settings.openai_api_key == "test-openai"
+    assert settings.indian_api_key == "test-indian"
+
+
+def test_ensure_api_keys(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    # create temporary settings
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    assert ensure_api_keys()
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert ensure_api_keys() is False

--- a/tests/test_data_provider.py
+++ b/tests/test_data_provider.py
@@ -1,0 +1,14 @@
+import asyncio
+from pathlib import Path
+import sys
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from agent_scripts.data_providers import DataProviderFactory
+
+@pytest.mark.asyncio
+async def test_yahoo_finance_provider():
+    provider = DataProviderFactory.create_yahoo_finance_provider()
+    data = await provider.get_stock_data('BHEL.NS', '2024-01-01', '2024-01-10', '1d')
+    assert data is not None
+    assert 'data' in data and not data['data'].empty

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,12 @@
+from agent_scripts import __version__
+import subprocess, sys
+
+
+def test_version_constant():
+    assert isinstance(__version__, str) and __version__
+
+
+def test_cli_version():
+    result = subprocess.run([sys.executable, '-m', 'agent_scripts.cli', '--version'], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert __version__ in result.stdout.strip()


### PR DESCRIPTION
## Summary
- remove hard-coded API key
- add CLI `--version` option with version constant
- provide simple tests for version and data fetching
- allow configuring output directory via `OUTPUT_DIR`
- add retry logic to stock data download

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856fb12e2688322886fa23fcf950ced